### PR TITLE
Document limitation around personal access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,16 @@ On Mac/Linux make it executable and readable for all users: `chmod a+rx <path>/d
 
 ## Limitations
 
-### conflict with Dockerhub 2FA auth
+### Conflict with Dockerhub 2FA auth
 
 Pushing READMEs to Dockerhub doesn't work if you have 2FA auth (two-factor authentication) enabled for your Dockerhub account. This is an unfortunate Dockerhub API limitation.
 
 There are indications (in issues and forum posts) that a new API for Dockerhub might be coming up sooner or later that might fill this gap. Fingers crossed. 🤞
     
-    
-    
+### Conflict with Dockerhub personal access token
+
+Pushing READMEs to Dockerhub doesn't work if you are using personal access tokens. You need to login using username and password. This is an unfortunate Dockerhub API limitation.
+
+
 ----
 All trademarks, logos and website designs belong to their respective owners.

--- a/provider/dockerhub/dockerhub.go
+++ b/provider/dockerhub/dockerhub.go
@@ -161,7 +161,7 @@ func PatchDescription(jwt string, readme string, namespacename string, reponame 
 			msg = msg + ". Server responded: \"" + dat["detail"].(string) + "\""
 		}
 		if res.StatusCode == 403 {
-			msg = msg + ". Try \"docker logout\" and \"docker login\". Also, if you have 2FA auth enabled in Dockerhub you'll need to disable it for this tool to work. (This is an unfortunate Dockerhub limitation, see docs for more infos.)"
+			msg = msg + ". Try \"docker logout\" and \"docker login\". You cannot use a personal access token to log in and must use username and password. If you have 2FA auth enabled in Dockerhub you'll need to disable it for this tool to work. (These are unfortunate Dockerhub limitations, see docs for more infos.)"
 
 		}
 		return fmt.Errorf(msg)


### PR DESCRIPTION
I just tried using `docker pushrm` (which is a great thing), but ran into the limitation that apparently it requires me to turn off 2FA (which is documented) _as well as_ using my proper password (instead of an access token for CI or similar) which is not documented.

I thought adding this info might be valuable for others when evaluating if they want to use this tool.

---

FWIW this is the error message that is returned when disabling 2FA but using an access token:

```
Server responded: "access to the resource is forbidden with personal access token"
```