### PR TITLE
Add option to pass config as environment variables

### DIFF
--- a/README-containers.md
+++ b/README-containers.md
@@ -38,6 +38,18 @@ Let's dissect this a bit:
 - we set `--debug` to get additional log output (optional)
 - we set the short description for the Dockerhub repo with `--short <string>` (optional)
 
+**Alternatively all params can also get set with environment variables:**
+
+```
+$ docker run --rm -t \
+-v $(pwd):/myvol \
+-e DOCKER_USER='my-user' -e DOCKER_PASS='my-pass' \
+-e PUSHRM_PROVIDER=dockerhub -e PUSHRM_FILE=/myvol/README.md \
+-e PUSHRM_SHORT='my short description' \
+-e PUSHRM_TARGET=docker.io/my-user/my-repo -e PUSHRM_DEBUG=1 \
+chko/docker-pushrm:1
+```
+
 #### Push a README file to a Harbor v2 registry server
 
 Use the `--provider harbor2` flag:
@@ -55,8 +67,9 @@ chko/docker-pushrm:1 --file /myvol/README.md \
 
 #### Push a README file to Quay.io or a Quay registry server
 
+
 - use the `--provider quay` flag
-- use env var `APIKEY__<SERVER>_<DOMAIN>` for apikey credentials
+- use env var `APIKEY__<SERVER>_<DOMAIN>` or `DOCKER_APIKEY` for apikey credentials
 
 ```
 $ ls
@@ -68,6 +81,27 @@ $ docker run --rm -t \
 chko/docker-pushrm:1 --file /myvol/README.md \ 
 --provider quay --debug quay.io/my-user/my-repo
 ```
+
+### env vars
+
+| env var                     | example value                  | description
+| --------------------------- | ------------------------------ | ----------------------------------------
+| `DOCKER_USER`               | `my-user`                      | login username
+| `DOCKER_PASS`               | `my-password`                  | login password
+| `DOCKER_APIKEY`             | `my-quay-api-key`              | quay api key
+| `APIKEY__<SERVER>_<DOMAIN>` | `my-quay-api-key`              | quay api key (alternative)
+| `PUSHRM_PROVIDER`           | `dockerhub`, `quay`, `harbor2` | repo provider type
+| `PUSHRM_SHORT`              | `my short description`         | set/update repo short description
+| `PUSHRM_FILE`               | `/myvol/README.md`             | path to the README file
+| `PUSHRM_DEBUG`              | `1`                            | enable verbose output
+| `PUSHRM_CONFIG`             | `/myvol/.docker/config.json`   | Docker config file (for credentials)
+| `PUSHRM_TARGET`             | `docker.io/my-user/my-repo`    | container repo ref
+
+Presedence:
+- Params specified with flags take precedence over env vars.
+- Login env vars take precedence over credentials from a Docker config file
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ To install the plugin for all users of a system copy it to the following path (i
 
 On Mac/Linux make it executable and readable for all users: `chmod a+rx <path>/docker-pushrm`
 
+## Using env vars instead of cmdline params
+
+All cmdline parameters can also be set as env vars with prefix `PUSHRM_`.    
+    
+Cmdline parameters take precedence over env vars. (Except for login env vars, which take precedence over the local credentials store).    
+    
+This is mainly intended for running this tool in a container in [12fa](https://12factor.net/config) style.    
+    
+A list of all supported env vars is [here](README-containers.md#env-vars).
+
 ## Limitations
 
 ### Conflict with Dockerhub personal access tokens and 2FA auth

--- a/cmd/pushrm.go
+++ b/cmd/pushrm.go
@@ -161,6 +161,19 @@ var pushrmCmd = &cobra.Command{
 	the future that support READMEs on the tag level.
 
 
+	Supported environment variables
+	===============================
+	
+	DOCKER_USER, DOCKER_PASS, DOCKER_APIKEY, APIKEY__<SERVER>_<DOMAIN>,
+	PUSHRM_PROVIDER, PUSHRM_SHORT, PUSHRM_FILE, PUSHRM_DEBUG, PUSHRM_CONFIG,
+	PUSHRM_TARGET
+
+	Commandline parameters take precedence over environment variables.
+	Login environment variables take precedence over the local credentials
+	store.
+
+
+
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := run(args); err != nil {

--- a/cmd/pushrm.go
+++ b/cmd/pushrm.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"errors"
 	"os"
 	"regexp"
 	"strings"
@@ -161,175 +162,191 @@ var pushrmCmd = &cobra.Command{
 
 
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		pushrmProvider := viper.GetString("provider")
-		pushrmFile := viper.GetString("file")
-		pushrmShortDesc := viper.GetString("short")
-
-		log.Debug("subcommand \"pushrm\" called")
-
-		//fmt.Println(os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND"))
-
-		// lowest common ground: 100 runes (not bytes) on Dockerhub
-		// this check is intentially global (not per provider) to
-		// make cmd calls portable between providers without surprises
-		if utf8.RuneCountInString(pushrmShortDesc) > 100 {
-			log.Error("Short description is too long (max 100 characters)")
-			os.Exit(1)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := run(args); err != nil {
+			return err
 		}
+		return nil
+	},
+}
 
-		// our only positional argument: <servername>/<namespacename>/<reponame>:<tag> (servername + tag are optional)
-		targetinfo := os.Getenv("PUSHRM_TARGET")
-		if len(args) > 0 {
-			if target := args[0]; target != "" {
-				targetinfo = target
-			}
-		}
-		// fail if namespacename is missing
-		if len(strings.Split(targetinfo, "/")) < 2 {
-			log.Error("Invalid [IMAGE] argument - missing namespace. Example: docker.io/mynamespace/myrepo:latest")
-			os.Exit(1)
-		}
-		// fill up default servername, if missing
-		if len(strings.Split(targetinfo, "/")) < 3 {
-			targetinfo = "docker.io/" + targetinfo
-		}
-		// fill up default tagname, if missing
-		if strings.Contains(targetinfo, ":") != true {
-			targetinfo = targetinfo + ":latest"
-		}
-		log.Debug("Using target: ", targetinfo)
+func run(args []string) error {
+	pushrmProvider := viper.GetString("provider")
+	pushrmFile := viper.GetString("file")
+	pushrmShortDesc := viper.GetString("short")
 
-		var erro error
+	log.Debug("subcommand \"pushrm\" called")
 
-		if pushrmFile == "" {
-			pushrmFile, erro = util.FindReadmeFile()
-			if erro != nil {
-				log.Error(erro)
-				os.Exit(1)
-			}
+	//fmt.Println(os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND"))
+
+	// lowest common ground: 100 runes (not bytes) on Dockerhub
+	// this check is intentially global (not per provider) to
+	// make cmd calls portable between providers without surprises
+	if utf8.RuneCountInString(pushrmShortDesc) > 100 {
+		log.Error("Short description is too long (max 100 characters)")
+		os.Exit(1)
+	}
+
+	// our only positional argument: <servername>/<namespacename>/<reponame>:<tag> (servername + tag are optional)
+	targetinfo := os.Getenv("PUSHRM_TARGET")
+	if len(args) > 0 {
+		if target := args[0]; target != "" {
+			targetinfo = target
 		}
+	}
 
-		log.Debug("using README file: " + pushrmFile)
+	if targetinfo == "" {
+		return (errors.New("Missing [IMAGE] argument. Example: docker.io/mynamespace/myrepo:latest"))
+		//log.Error("Missing [IMAGE] argument. Example: docker.io/mynamespace/myrepo:latest")
+		//os.Exit(1)
+	}
 
-		readme, erro := util.ReadFile(pushrmFile)
+	// fail if namespacename is missing
+	if len(strings.Split(targetinfo, "/")) < 2 {
+		log.Error("Invalid [IMAGE] argument - missing namespace. Example: docker.io/mynamespace/myrepo:latest")
+		os.Exit(1)
+	}
+	// fill up default servername, if missing
+	if len(strings.Split(targetinfo, "/")) < 3 {
+		targetinfo = "docker.io/" + targetinfo
+	}
+	// fill up default tagname, if missing
+	if strings.Contains(targetinfo, ":") != true {
+		targetinfo = targetinfo + ":latest"
+	}
+	log.Debug("Using target: ", targetinfo)
+
+	var erro error
+
+	if pushrmFile == "" {
+		pushrmFile, erro = util.FindReadmeFile()
 		if erro != nil {
 			log.Error(erro)
 			os.Exit(1)
 		}
+	}
 
-		if (len(strings.Split(targetinfo, "/")) != 3) || (len(strings.Split(strings.Split(targetinfo, "/")[2], ":")) != 2) {
-			log.Error("Invalid [IMAGE] argument - too many separators. Example: docker.io/mynamespace/myrepo:latest")
+	log.Debug("using README file: " + pushrmFile)
+
+	readme, erro := util.ReadFile(pushrmFile)
+	if erro != nil {
+		log.Error(erro)
+		os.Exit(1)
+	}
+
+	if (len(strings.Split(targetinfo, "/")) != 3) || (len(strings.Split(strings.Split(targetinfo, "/")[2], ":")) != 2) {
+		log.Error("Invalid [IMAGE] argument - too many separators. Example: docker.io/mynamespace/myrepo:latest")
+		os.Exit(1)
+	}
+
+	servername := strings.ToLower(strings.Split(targetinfo, "/")[0])
+	namespacename := strings.Split(targetinfo, "/")[1]
+	reponame := strings.Split(strings.Split(targetinfo, "/")[2], ":")[0]
+	tagname := strings.Split(strings.Split(targetinfo, "/")[2], ":")[1]
+	if servername == "docker.io" {
+		pushrmProvider = "dockerhub"
+	}
+	if servername == "quay.io" {
+		pushrmProvider = "quay"
+	}
+	log.Debug("server: ", servername)
+	log.Debug("namespace: ", namespacename)
+	log.Debug("repo: ", reponame)
+	log.Debug("tag: ", tagname)
+	log.Debug("repo provider: ", pushrmProvider)
+
+	for _, e := range []string{namespacename, reponame, tagname, servername} {
+		// yes, dots are allowed in all these fields
+		if regexp.MustCompile(`^[0-9a-zA-Z\-_.]+$`).MatchString(e) == false {
+			log.Error("Invalid [IMAGE argument] - bad characters or empty value. Example: docker.io/mynamespace/myrepo:latest")
 			os.Exit(1)
 		}
+	}
 
-		servername := strings.ToLower(strings.Split(targetinfo, "/")[0])
-		namespacename := strings.Split(targetinfo, "/")[1]
-		reponame := strings.Split(strings.Split(targetinfo, "/")[2], ":")[0]
-		tagname := strings.Split(strings.Split(targetinfo, "/")[2], ":")[1]
-		if servername == "docker.io" {
-			pushrmProvider = "dockerhub"
-		}
-		if servername == "quay.io" {
-			pushrmProvider = "quay"
-		}
-		log.Debug("server: ", servername)
-		log.Debug("namespace: ", namespacename)
-		log.Debug("repo: ", reponame)
-		log.Debug("tag: ", tagname)
-		log.Debug("repo provider: ", pushrmProvider)
+	if pushrmProvider == "dockerhub" && servername != "docker.io" {
+		log.Error("servername ", servername, " is not valid for provider ", pushrmProvider, " (try \"docker.io\")")
+		os.Exit(1)
+	}
 
-		for _, e := range []string{namespacename, reponame, tagname, servername} {
-			// yes, dots are allowed in all these fields
-			if regexp.MustCompile(`^[0-9a-zA-Z\-_.]+$`).MatchString(e) == false {
-				log.Error("Invalid [IMAGE argument] - bad characters or empty value. Example: docker.io/mynamespace/myrepo:latest")
-				os.Exit(1)
-			}
-		}
+	var prov provider.Provider
 
-		if pushrmProvider == "dockerhub" && servername != "docker.io" {
-			log.Error("servername ", servername, " is not valid for provider ", pushrmProvider, " (try \"docker.io\")")
-			os.Exit(1)
-		}
+	switch pushrmProvider {
+	case "dockerhub":
+		prov = dockerhub.Dockerhub{}
+	case "quay":
+		prov = quay.Quay{}
+	case "harbor2":
+		prov = harbor2.Harbor2{}
+	default:
+		log.Error("unsupported repo provider: ", pushrmProvider+". See \"--help\" for supported providers. ")
+		os.Exit(1)
+	}
 
-		var prov provider.Provider
+	authident := prov.GetAuthident()
+	var authidentIsFuzzy bool
+	authidentIsFuzzy = false
 
-		switch pushrmProvider {
-		case "dockerhub":
-			prov = dockerhub.Dockerhub{}
-		case "quay":
-			prov = quay.Quay{}
-		case "harbor2":
-			prov = harbor2.Harbor2{}
-		default:
-			log.Error("unsupported repo provider: ", pushrmProvider+". See \"--help\" for supported providers. ")
-			os.Exit(1)
-		}
+	if authident == "__SERVERNAME__" {
+		authident = servername
+		authidentIsFuzzy = true
+	}
 
-		authident := prov.GetAuthident()
-		var authidentIsFuzzy bool
-		authidentIsFuzzy = false
+	var dockerUser string
+	var dockerPasswd string
+	var err error
 
-		if authident == "__SERVERNAME__" {
-			authident = servername
-			authidentIsFuzzy = true
-		}
+	// generic env var (no servername specified) takes precedence
+	dockerUser = os.Getenv("DOCKER_USER")
+	dockerPasswd = os.Getenv("DOCKER_PASS")
+	if dockerUser != "" && dockerPasswd != "" {
+		log.Debug("using credentials for user " + dockerUser + " from generic env var")
+	}
 
-		var dockerUser string
-		var dockerPasswd string
-		var err error
-
-		// generic env var (no servername specified) takes precedence
-		dockerUser = os.Getenv("DOCKER_USER")
-		dockerPasswd = os.Getenv("DOCKER_PASS")
+	// env var with servername is next
+	if dockerUser == "" || dockerPasswd == "" {
+		suffix := strings.ToUpper(strings.Replace(servername, ".", "_", -1))
+		dockerUser = os.Getenv("DOCKER_USER__" + suffix)
+		dockerPasswd = os.Getenv("DOCKER_PASS__" + suffix)
 		if dockerUser != "" && dockerPasswd != "" {
-			log.Debug("using credentials for user " + dockerUser + " from generic env var")
+			log.Debug("using credentials for user " + dockerUser + " from env var for suffix " + suffix)
 		}
+	}
 
-		// env var with servername is next
-		if dockerUser == "" || dockerPasswd == "" {
-			suffix := strings.ToUpper(strings.Replace(servername, ".", "_", -1))
-			dockerUser = os.Getenv("DOCKER_USER__" + suffix)
-			dockerPasswd = os.Getenv("DOCKER_PASS__" + suffix)
-			if dockerUser != "" && dockerPasswd != "" {
-				log.Debug("using credentials for user " + dockerUser + " from env var for suffix " + suffix)
-			}
-		}
+	// if credentials are not found in env vars, look in the Docker credentials store
+	if (dockerUser == "" || dockerPasswd == "") && authident != "__NONE__" {
+		log.Debug("no credentials found in env vars. Trying Docker credentials store")
+		log.Debug("Using config file: ", viper.ConfigFileUsed())
 
-		// if credentials are not found in env vars, look in the Docker credentials store
-		if (dockerUser == "" || dockerPasswd == "") && authident != "__NONE__" {
-			log.Debug("no credentials found in env vars. Trying Docker credentials store")
-			log.Debug("Using config file: ", viper.ConfigFileUsed())
-
-			if viper.ConfigFileUsed() == "" {
-				log.Error("Docker config file not found. Run \"docker login\" first to create it. ")
-				os.Exit(1)
-			}
-
-			// a provider can request to handle auth itself with authident __NONE__
-			if authident != "__NONE__" {
-				dockerUser, dockerPasswd, err = util.GetDockerCreds(authident, authidentIsFuzzy)
-				if err != nil {
-					log.Error(err)
-					os.Exit(1)
-				}
-			} else {
-				dockerUser = ""
-				dockerPasswd = ""
-			}
-		}
-
-		//log.Debug("Using Docker creds: ", dockerUser, " ", dockerPasswd)
-		log.Debug("Using Docker creds: ", dockerUser, " ", "********")
-
-		err = prov.Pushrm(servername, namespacename, reponame, tagname, dockerUser, dockerPasswd, readme, pushrmShortDesc)
-		if err != nil {
-			log.Error(err)
+		if viper.ConfigFileUsed() == "" {
+			log.Error("Docker config file not found. Run \"docker login\" first to create it. ")
 			os.Exit(1)
 		}
 
-		// ---------
-	},
+		// a provider can request to handle auth itself with authident __NONE__
+		if authident != "__NONE__" {
+			dockerUser, dockerPasswd, err = util.GetDockerCreds(authident, authidentIsFuzzy)
+			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+		} else {
+			dockerUser = ""
+			dockerPasswd = ""
+		}
+	}
+
+	//log.Debug("Using Docker creds: ", dockerUser, " ", dockerPasswd)
+	log.Debug("Using Docker creds: ", dockerUser, " ", "********")
+
+	err = prov.Pushrm(servername, namespacename, reponame, tagname, dockerUser, dockerPasswd, readme, pushrmShortDesc)
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	return nil
+
+	// ---------
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,9 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("tlscert")
 	rootCmd.PersistentFlags().MarkHidden("tlskey")
 
+	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
+	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
@@ -107,7 +110,13 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if isDebug {
+	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvPrefix("pushrm")
+
+	pushrmConfig := viper.GetString("config")
+	pushrmDebug := viper.GetBool("debug")
+
+	if pushrmDebug {
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.WarnLevel)
@@ -116,9 +125,9 @@ func initConfig() {
 
 	log.Debug("root cmd init config")
 
-	if cfgFile != "" {
+	if pushrmConfig != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(pushrmConfig)
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
@@ -134,9 +143,6 @@ func initConfig() {
 
 		viper.SetConfigName("config") //filename without .json extension
 	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-	viper.SetEnvPrefix("pushrm")
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,6 +136,7 @@ func initConfig() {
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvPrefix("pushrm")
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {


### PR DESCRIPTION
Possible environment variables (example values):

- `PUSHRM_TARGET=registry.example.com/repo/demo`
- `--provider` `PUSHRM_PROVIDER=quay`
- `--file` `PUSHRM_FILE=README-custom.md`
- `--short` `PUSHRM_SHORT="My docker image desc"`
- `--config` `PUSHRM_CONFIG=./path/to/conf`
- `-D` `PUSHRM_DEBUG=true`

Default behavior is kept unchanged, args/cli flags will always win.